### PR TITLE
fix: 이미지 갯수에 따라 ThreePictureView가 유동적으로 변하게 수정함

### DIFF
--- a/ThreePicDiary/ThreePicDiary/View/ChildView/ThreePictureView.swift
+++ b/ThreePicDiary/ThreePicDiary/View/ChildView/ThreePictureView.swift
@@ -25,8 +25,6 @@ final class ThreePictureView: UIView {
         layer.masksToBounds = true
         
         setViews()
-        addViews()
-        addConstraints()
     }
     
     required init?(coder: NSCoder) {
@@ -36,6 +34,9 @@ final class ThreePictureView: UIView {
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
         delegate?.setPictures()
+        
+        addViews()
+        addConstraints()
     }
     
     private func setViews() {
@@ -50,30 +51,61 @@ final class ThreePictureView: UIView {
     }
     
     private func addViews() {
-        self.addSubview(firstImageView)
-        self.addSubview(secondImageView)
-        self.addSubview(thirdImageView)
+        if secondImageView.image == nil && thirdImageView.image == nil {
+            self.addSubview(firstImageView)
+        } else if thirdImageView.image == nil {
+            self.addSubview(firstImageView)
+            self.addSubview(secondImageView)
+        } else {
+            self.addSubview(firstImageView)
+            self.addSubview(secondImageView)
+            self.addSubview(thirdImageView)
+        }
+        
     }
     
     private func addConstraints() {
-        NSLayoutConstraint.activate([
-            firstImageView.topAnchor.constraint(equalTo: self.topAnchor),
-            firstImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            firstImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            firstImageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
+        if secondImageView.image == nil && thirdImageView.image == nil {
+            NSLayoutConstraint.activate([
+                firstImageView.topAnchor.constraint(equalTo: self.topAnchor),
+                firstImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                firstImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                firstImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            ])
+        } else if thirdImageView.image == nil {
+            NSLayoutConstraint.activate([
+                firstImageView.topAnchor.constraint(equalTo: self.topAnchor),
+                firstImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                firstImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+                firstImageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
+                
+                secondImageView.topAnchor.constraint(equalTo: self.topAnchor),
+                secondImageView.leadingAnchor.constraint(equalTo: firstImageView.trailingAnchor),
+                secondImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                secondImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            ])
             
-            secondImageView.topAnchor.constraint(equalTo: self.topAnchor),
-            secondImageView.leadingAnchor.constraint(equalTo: firstImageView.trailingAnchor),
-            secondImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            secondImageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
-            secondImageView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.5),
-            
-            thirdImageView.topAnchor.constraint(equalTo: secondImageView.bottomAnchor),
-            thirdImageView.leadingAnchor.constraint(equalTo: secondImageView.leadingAnchor),
-            thirdImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            thirdImageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
-            thirdImageView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.5),
-        ])
+        } else {
+            NSLayoutConstraint.activate([
+                firstImageView.topAnchor.constraint(equalTo: self.topAnchor),
+                firstImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+                firstImageView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+                firstImageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
+                
+                secondImageView.topAnchor.constraint(equalTo: self.topAnchor),
+                secondImageView.leadingAnchor.constraint(equalTo: firstImageView.trailingAnchor),
+                secondImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                secondImageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
+                secondImageView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.5),
+                
+                thirdImageView.topAnchor.constraint(equalTo: secondImageView.bottomAnchor),
+                thirdImageView.leadingAnchor.constraint(equalTo: secondImageView.leadingAnchor),
+                thirdImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+                thirdImageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
+                thirdImageView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.5),
+            ])
+        }
+       
     }
     
 }


### PR DESCRIPTION
이전에는 고정된 위치와 사이즈를 가져 이미지가 한개나 혹은 두개여도 빈자리가 그대로 남아있었지만,
이젠 이미지 갯수에 따라 유동적으로 영역의 전체를 업로드한 이미지가 덮도록 수정함.